### PR TITLE
Investigate macos build timeouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,60 @@ jobs:
   build-macos-arm64:
     name: Build macOS (arm64)
     runs-on: macos-15-arm64
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      
+      # Cache Rust dependencies
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+      
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
+      
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-target-
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+      
       - name: Build wheels (arm64)
         uses: PyO3/maturin-action@v1
         with:
           command: build
+          target: aarch64-apple-darwin
           args: >-
             --release
-            --find-interpreter
+            --interpreter python3.8 python3.9 python3.10 python3.11 python3.12 python3.13
+          before-build-linux: |
+            rustup update stable
+          manylinux: off
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 11.0
+      
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -62,10 +107,49 @@ jobs:
   build-macos-x86_64:
     name: Build macOS (x86_64 via cross-compile)
     runs-on: macos-15-arm64
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      
+      # Cache Rust dependencies
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+      
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
+      
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-x86_64-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-x86_64-cargo-build-target-
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+      
       - name: Add Rust target x86_64-apple-darwin
         run: rustup target add x86_64-apple-darwin
+      
       - name: Build wheels (x86_64)
         uses: PyO3/maturin-action@v1
         with:
@@ -73,10 +157,13 @@ jobs:
           target: x86_64-apple-darwin
           args: >-
             --release
-            --find-interpreter
+            --interpreter python3.8 python3.9 python3.10 python3.11 python3.12 python3.13
+          before-build-linux: |
+            rustup update stable
+          manylinux: off
         env:
-          # Reasonable baseline; tweak if you need older macOS support.
           MACOSX_DEPLOYMENT_TARGET: 11.0
+      
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Address Mac build timeouts by adding caching, explicit timeouts, and refined Python setup in `release.yml`.

---
<a href="https://cursor.com/background-agent?bcId=bc-576478bc-c503-472e-9e53-ba27b5bd54a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-576478bc-c503-472e-9e53-ba27b5bd54a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

