### PR TITLE
Investigate macos build timeouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,90 @@ env:
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
 
 jobs:
+  build-macos-arm64:
+    name: Build macOS (arm64)
+    runs-on: macos-15-arm64
+    timeout-minutes: 120  # 2 hours timeout
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      
+      - name: Build wheels (arm64)
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: >-
+            --release
+            --find-interpreter
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-arm64
+          path: target/wheels/*
+
+  build-macos-x86_64:
+    name: Build macOS (x86_64 via cross-compile)
+    runs-on: macos-15-arm64
+    timeout-minutes: 150  # 2.5 hours timeout for cross-compilation
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      
+      - name: Add Rust target x86_64-apple-darwin
+        run: rustup target add x86_64-apple-darwin
+      - name: Build wheels (x86_64)
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          target: x86_64-apple-darwin
+          args: >-
+            --release
+            --find-interpreter
+        env:
+          # Reasonable baseline; tweak if you need older macOS support.
+          MACOSX_DEPLOYMENT_TARGET: 11.0
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-x86_64
+          path: target/wheels/*
+
   build-linux:
     name: Build Linux (manylinux_2_17 x86_64; CPython only)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       # Build only against CPython interpreters in the manylinux image.
       # This avoids PyPy 3.11 which pyo3 0.21.x doesn't support.
@@ -41,53 +120,24 @@ jobs:
           name: wheels-linux
           path: target/wheels/*
 
-  build-macos-arm64:
-    name: Build macOS (arm64)
-    runs-on: macos-15-arm64
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build wheels (arm64)
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          args: >-
-            --release
-            --find-interpreter
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-arm64
-          path: target/wheels/*
-
-  build-macos-x86_64:
-    name: Build macOS (x86_64 via cross-compile)
-    runs-on: macos-15-arm64
-    steps:
-      - uses: actions/checkout@v4
-      - name: Add Rust target x86_64-apple-darwin
-        run: rustup target add x86_64-apple-darwin
-      - name: Build wheels (x86_64)
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          target: x86_64-apple-darwin
-          args: >-
-            --release
-            --find-interpreter
-        env:
-          # Reasonable baseline; tweak if you need older macOS support.
-          MACOSX_DEPLOYMENT_TARGET: 11.0
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-macos-x86_64
-          path: target/wheels/*
 
   build-windows:
     name: Build Windows (x86_64)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -119,6 +169,7 @@ jobs:
   release:
     name: Create GitHub Release & Publish to PyPI
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # 30 minutes timeout for release
     needs:
       - build-linux
       - build-macos-arm64


### PR DESCRIPTION
Add explicit timeouts and Rust/Cargo caching to the GitHub Actions release workflow to fix macOS build timeouts and improve overall build performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-b36e2a44-816a-43f0-9d7e-c977b7a65d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b36e2a44-816a-43f0-9d7e-c977b7a65d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

